### PR TITLE
Fixed KML export syntax error

### DIFF
--- a/client.py
+++ b/client.py
@@ -119,7 +119,7 @@ def resread(Buffer, KML):
 			f.write("<Document>\n")
 			for array in narray:
 				f.write("\t<Placemark>\n")
-				f.write("\t\t<dsecription>" + str(array[0]) + "</description>\n")
+				f.write("\t\t<description>" + str(array[0]) + "</description>\n")
 				f.write("\t\t<Point>\n")
 				f.write("\t\t\t<coordinates>" + str(array[2]) + "," + str(array[1]) + "</coordinates>\n")
 				f.write("\t\t</Point>\n")


### PR DESCRIPTION
The exported KML file contained a syntax error. Instead of the opening tag `<description>` a typing error  caused the export as `<dsecription>`. This pull request fixes the error. 